### PR TITLE
Allow custom plot formatters + use one for memory graph

### DIFF
--- a/perf8/plugins/_asyncstats.py
+++ b/perf8/plugins/_asyncstats.py
@@ -86,7 +86,7 @@ class EventLoopMonitoring(AsyncBasePlugin):
             return int(row[1])
 
         loop_file = self.generate_plot(
-            self.report_file, extract_lag, "Event loop lag", "Seconds", "loop_lag.png"
+            self.report_file, extract_lag, "Event loop lag", "Seconds", "loop_lag.png", None
         )
         coro_file = self.generate_plot(
             self.report_file,
@@ -94,6 +94,7 @@ class EventLoopMonitoring(AsyncBasePlugin):
             "Tasks concurrency",
             "tasks",
             "loop_coro.png",
+            None
         )
 
         return [

--- a/perf8/plugins/_psutil.py
+++ b/perf8/plugins/_psutil.py
@@ -22,6 +22,7 @@ import os
 import psutil
 import humanize
 
+import matplotlib.ticker as tkr
 from perf8.plugins.base import BasePlugin, register_plugin
 
 
@@ -95,15 +96,16 @@ class ResourceWatcher(BasePlugin):
         plot_files = self.generate_plots(
             self.report_file,
             [
-                lambda row: humanize.naturalsize(float(row[0]), binary=True),
+                lambda row: float(row[0]),
                 "Memory Usage (RSS)",
                 "Bytes",
                 "rss.png",
+                tkr.FuncFormatter(humanize.naturalsize)
             ],
-            [lambda row: float(row[6]), "CPU%", "%", "cpu.png"],
-            [lambda row: int(row[2]), "Threads", "ths", "threads.png"],
-            [lambda row: int(row[1]), "File Descriptors", "FDs", "fds.png"],
-            [lambda row: int(row[3]), "Context Switches", "ctx", "ctx.png"],
+            [lambda row: float(row[6]), "CPU%", "%", "cpu.png", None],
+            [lambda row: int(row[2]), "Threads", "ths", "threads.png", None],
+            [lambda row: int(row[1]), "File Descriptors", "FDs", "fds.png", None],
+            [lambda row: int(row[3]), "Context Switches", "ctx", "ctx.png", None],
         )
 
         return [

--- a/perf8/plugins/base.py
+++ b/perf8/plugins/base.py
@@ -159,11 +159,11 @@ class BasePlugin:
 
         self.info(f"Loaded {len(rows)} data points from {path}")
         plots = []
-        for extract_field, title, ylabel, target in plot_defs:
-            plots.append(self.generate_plot(rows, extract_field, title, ylabel, target))
+        for extract_field, title, ylabel, target, yformatter in plot_defs:
+            plots.append(self.generate_plot(rows, extract_field, title, ylabel, target, yformatter))
         return plots
 
-    def generate_plot(self, path_or_rows, extract_field, title, ylabel, target):
+    def generate_plot(self, path_or_rows, extract_field, title, ylabel, target, yformatter):
         x = []
         y = []
 
@@ -190,6 +190,9 @@ class BasePlugin:
         plt.xticks(rotation=25)
         plt.xlabel("Duration (s)")
         plt.ylabel(ylabel)
+        if yformatter:
+            ax = plt.gca()
+            ax.yaxis.set_major_formatter(yformatter)
         plt.title(title, fontsize=20)
         plt.grid()
         plt.legend()


### PR DESCRIPTION
Problem: memory graph data does not make sense - the Y axis is not properly sorted by the value because the data is formatted before going into plot and becomes strings.

Solution: use y axis formatter instead of formatting data and sending it to plot.

Before (notice that graph is linear while dots on Y axis do not show a linear progression):

![image](https://user-images.githubusercontent.com/12238374/231747309-312613c8-310f-4592-ae2a-de360671ea33.png)


After:

![image](https://user-images.githubusercontent.com/12238374/231747822-c76992c1-7983-496c-b97b-87a323f3b3f4.png)
