### PR TITLE
Add _annotate_max that highlights max y value on plots

### DIFF
--- a/perf8/plugins/base.py
+++ b/perf8/plugins/base.py
@@ -217,25 +217,56 @@ class BasePlugin:
             if cvsfile is not None:
                 cvsfile.close()
 
-        plt.cla()
+        plt.clf()
         plt.plot(x, y, color="g", linestyle="dashed", marker="o", label=title)
 
         plt.xticks(rotation=25)
         plt.xlabel("Duration (s)")
         plt.ylabel(ylabel)
+        ax = plt.gca()
         if yformatter:
-            ax = plt.gca()
             ax.yaxis.set_major_formatter(yformatter)
         plt.title(title, fontsize=20)
         if threshold is not None and threshold < max:
             plt.axhline(threshold, color="r")
         plt.grid()
-        plt.legend()
+        self._annotate_max(plt, ax, x, y, yformatter)
         plot_file = os.path.join(self.target_dir, target)
         self.info(f"Saved plot file at {plot_file}")
         plt.savefig(plot_file)
         return plot_file
 
+    def _annotate_max(self, plt, ax, x,y, yformatter=None):
+        """
+        This function creates a second plot on top of original one
+        and marks only the maximum value on it.
+
+        Also adds another yaxis on the right wthat has only
+        label for the maximum value
+        """
+
+        # Get the coordinate for maximum Y
+        ymax = max(y)
+        x_for_ymax= x[y.index(ymax)]
+
+        # Copy the plot while also moving
+        # Yaxis labels to the right
+        ax2 = ax.twinx()
+
+        # First draw same figure but invisible
+        # Why? Cause otherwise Y axis label will
+        # look weird :(
+        ax2.plot(x, y, 'r-', alpha=0)
+
+        # Also draw red dot for the max value
+        ax2.plot(x_for_ymax, ymax, 'ro')
+
+        # Keep only label for maximum Y on our axis
+        ax2.set_yticks([ymax])
+
+        # Don't forget to format it
+        if yformatter:
+            ax2.yaxis.set_major_formatter(yformatter)
 
 class AsyncBasePlugin(BasePlugin):
     is_async = True

--- a/perf8/plugins/base.py
+++ b/perf8/plugins/base.py
@@ -244,6 +244,8 @@ class BasePlugin:
         Also adds another yaxis on the right wthat has only
         label for the maximum value
         """
+        if not x or not y:
+            return
 
         # Get the coordinate for maximum Y
         ymax = max(y)

--- a/perf8/plugins/base.py
+++ b/perf8/plugins/base.py
@@ -236,7 +236,7 @@ class BasePlugin:
         plt.savefig(plot_file)
         return plot_file
 
-    def _annotate_max(self, plt, ax, x,y, yformatter=None):
+    def _annotate_max(self, plt, ax, x, y, yformatter=None):
         """
         This function creates a second plot on top of original one
         and marks only the maximum value on it.
@@ -247,7 +247,7 @@ class BasePlugin:
 
         # Get the coordinate for maximum Y
         ymax = max(y)
-        x_for_ymax= x[y.index(ymax)]
+        x_for_ymax = x[y.index(ymax)]
 
         # Copy the plot while also moving
         # Yaxis labels to the right
@@ -256,10 +256,10 @@ class BasePlugin:
         # First draw same figure but invisible
         # Why? Cause otherwise Y axis label will
         # look weird :(
-        ax2.plot(x, y, 'r-', alpha=0)
+        ax2.plot(x, y, "r-", alpha=0)
 
         # Also draw red dot for the max value
-        ax2.plot(x_for_ymax, ymax, 'ro')
+        ax2.plot(x_for_ymax, ymax, "ro")
 
         # Keep only label for maximum Y on our axis
         ax2.set_yticks([ymax])
@@ -267,6 +267,7 @@ class BasePlugin:
         # Don't forget to format it
         if yformatter:
             ax2.yaxis.set_major_formatter(yformatter)
+
 
 class AsyncBasePlugin(BasePlugin):
     is_async = True


### PR DESCRIPTION
This change makes maximum Y values more visible on the plot by highlighting the dot with red and displaying a label on the right Y axis of the plot. See screenshots.

Before:
![image](https://user-images.githubusercontent.com/12238374/234633648-83c5e926-fbb1-4ba1-8353-abb316f4a8fa.png)


After:
![image](https://user-images.githubusercontent.com/12238374/234633438-79c6d226-6e89-4e69-9bb9-36caeba33346.png)
