### PR TITLE
bump matplotlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+share
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -137,3 +138,7 @@ dmypy.json
 
 # test reports
 perf8-report/
+
+# jetbrains
+.idea
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIRS = bin build include lib lib64 man share
 VIRTUALENV = virtualenv
 SYSTEM_PYTHON = python3.10
 
-.PHONY: all test build clean docs
+.PHONY: all install test build clean docs
 
 all: build
 
@@ -15,6 +15,12 @@ $(PYTHON):
 	$(BIN)/pip install -r requirements.txt
 	$(BIN)/pip install tox
 	$(BIN)/pip install twine
+
+install: $(PYTHON)
+	bin/pip install -e .
+
+dev: install
+	bin/pip install -r tests-requirements.txt
 
 clean:
 	rm -rf $(BUILD_DIRS)

--- a/perf8/plugins/_psutil.py
+++ b/perf8/plugins/_psutil.py
@@ -121,6 +121,9 @@ class ResourceWatcher(BasePlugin):
 
         self.debug("Probing")
         probed_at = time.time()
+        if info.get("memory_info") is None:
+            self.warning("Proc info is empty")
+            return
         current_rss = info["memory_info"].rss
         if current_rss > self.max_rss:
             self.max_rss = current_rss

--- a/perf8/tests/ademo.py
+++ b/perf8/tests/ademo.py
@@ -62,7 +62,7 @@ async def add_mem3():
     data.append("r" * get_random(100, 20000))
 
 
-def some_math(i):
+async def some_math(i):
     if get_random(1, 20) == 2:
         print(f"[{os.getpid()}] Busy adding data! ({i}/{RANGE})")
         try:
@@ -82,7 +82,7 @@ async def main():
             # blocks for 2 secs
             time.sleep(2)
 
-        t3 = asyncio.get_running_loop().run_in_executor(None, some_math, i)
+        t3 = asyncio.create_task(some_math(i))
         await asyncio.gather(t, t2, t3)
 
     await disable()

--- a/perf8/tests/test_watcher.py
+++ b/perf8/tests/test_watcher.py
@@ -63,7 +63,7 @@ async def test_async_watcher():
         refresh_rate = 0.1
         psutil = True
         cprofile = False
-        memray = True
+        memray = False
         asyncstats = True
         pyspy = False
         target_dir = tempfile.mkdtemp()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psutil==5.9.5
-matplotlib==3.7.2
+matplotlib==3.9.0
 flameprof==0.4
 memray==1.9.0
 gprof2dot==2022.7.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-psutil==5.9.5
-matplotlib==3.9.0
-flameprof==0.4
-memray==1.9.0
-gprof2dot==2022.7.29
-py-spy==0.3.14
-importlib-metadata==6.8.0
-Jinja2==3.1.2
-humanize==4.7.0
-statsd==4.0.1
+psutil>=5.9.5, <6.0.0
+matplotlib>=3.9.0, <4.0.0
+flameprof>=0.4, <1.0
+memray>=1.9.0, <2.0.0
+gprof2dot>=2022.7.29
+py-spy>=0.3.14, <1.0.0
+importlib-metadata>=6.8.0, <7.0.0
+Jinja2>=3.1.4, <4.0.0
+humanize>=4.7.0, <5.0.0
+statsd>=4.0.1, <5.0.0


### PR DESCRIPTION
Replaces https://github.com/elastic/perf8/pull/16, this attempts to instead constrain, but not pin, our deps for this library.

Also adds a `make install` and `make dev` to make local development less painful.

Also fixes a few issues that were causing test failures. CI is still failing (permission error on socket bind?) but running `make test` locally passes